### PR TITLE
Pin the ca-certificates as part of .erlang-rundeps

### DIFF
--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -57,7 +57,10 @@ RUN set -xe \
 	&& HOME=$PWD ./bootstrap \
 	&& install -v ./rebar3 /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar3-src \
-	&& apk add --virtual .erlang-rundeps $runDeps lksctp-tools \
+	&& apk add --virtual .erlang-rundeps \
+		$runDeps \
+		lksctp-tools \
+		ca-certificates \
 	&& apk del .fetch-deps .build-deps
 
 CMD ["erl"]

--- a/21/alpine/Dockerfile
+++ b/21/alpine/Dockerfile
@@ -57,7 +57,10 @@ RUN set -xe \
 	&& HOME=$PWD ./bootstrap \
 	&& install -v ./rebar3 /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar3-src \
-	&& apk add --virtual .erlang-rundeps $runDeps lksctp-tools \
+	&& apk add --virtual .erlang-rundeps \
+		$runDeps \
+		lksctp-tools \
+		ca-certificates \
 	&& apk del .fetch-deps .build-deps
 
 CMD ["erl"]


### PR DESCRIPTION
This resolves c0b/docker-elixir#46 will add ca-certificates for both erlang/elixir's alpine images.

will increase alpine image size by 0.6MB; from 74.6MB to 75.2MB.