### PR TITLE
Add a jessie flavour for erlang/otp 21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ env:
   - DIR=21
   - DIR=21 VARIANT=slim
   - DIR=21 VARIANT=alpine
+  - DIR=21 VARIANT=jessie
   - DIR=20
   - DIR=20 VARIANT=slim
   - DIR=20 VARIANT=alpine
   - DIR=19
   - DIR=19 VARIANT=slim
-  - DIR=18
-  - DIR=18 VARIANT=slim
 
 before_script:
   - cd "$DIR"

--- a/21/jessie/Dockerfile
+++ b/21/jessie/Dockerfile
@@ -1,0 +1,67 @@
+FROM buildpack-deps:jessie
+
+ENV OTP_VERSION="21.0.3"
+
+# We'll install the build dependencies for erlang-odbc along with the erlang
+# build process:
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="81ed829f829d53ce7dd7e3808eb3162ef672d52bd3ebc1ad1b6c6dafc06cc324" \
+	&& runtimeDeps='libodbc1 \
+			libsctp1 \
+			libwxgtk3.0' \
+	&& buildDeps='unixodbc-dev \
+			libsctp-dev \
+			libwxgtk3.0-dev' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $runtimeDeps \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp $ERL_TOP \
+	&& tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( cd $ERL_TOP \
+	  && ./otp_build autoconf \
+	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && ./configure --build="$gnuArch" \
+	  && make -j$(nproc) \
+	  && make install ) \
+	&& find /usr/local -name examples | xargs rm -rf \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf $ERL_TOP /var/lib/apt/lists/*
+
+CMD ["erl"]
+
+# extra useful tools here: rebar & rebar3
+
+ENV REBAR_VERSION="2.6.4"
+
+RUN set -xe \
+	&& REBAR_DOWNLOAD_URL="https://github.com/rebar/rebar/archive/${REBAR_VERSION}.tar.gz" \
+	&& REBAR_DOWNLOAD_SHA256="577246bafa2eb2b2c3f1d0c157408650446884555bf87901508ce71d5cc0bd07" \
+	&& mkdir -p /usr/src/rebar-src \
+	&& curl -fSL -o rebar-src.tar.gz "$REBAR_DOWNLOAD_URL" \
+	&& echo "$REBAR_DOWNLOAD_SHA256 rebar-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar-src.tar.gz -C /usr/src/rebar-src --strip-components=1 \
+	&& rm rebar-src.tar.gz \
+	&& cd /usr/src/rebar-src \
+	&& ./bootstrap \
+	&& install -v ./rebar /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar-src
+
+ENV REBAR3_VERSION="3.6.1"
+
+RUN set -xe \
+	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+	&& REBAR3_DOWNLOAD_SHA256="40b3c85440f3235c7b149578d0211bdf57d1c66390f888bb771704f8abc71033" \
+	&& mkdir -p /usr/src/rebar3-src \
+	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
+	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
+	&& rm rebar3-src.tar.gz \
+	&& cd /usr/src/rebar3-src \
+	&& HOME=$PWD ./bootstrap \
+	&& install -v ./rebar3 /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar3-src


### PR DESCRIPTION
Add a jessie flavour for erlang/otp 21  …

```diff
$ diff -urNp ./21/Dockerfile ./21/jessie/Dockerfile
--- ./21/Dockerfile	2018-07-16 02:06:24.484885290 -0700
+++ ./21/jessie/Dockerfile	2018-07-16 02:10:18.334921559 -0700
@@ -1,4 +1,4 @@
-FROM buildpack-deps:stretch
+FROM buildpack-deps:jessie

 ENV OTP_VERSION="21.0.3"
```

Start with Erlang OTP 21 only,  because there are 12 cominbations already on docker hub, not to keep too many combinations there, keep maintainers effort low, usually we're looking forward for future versions only, if you're still asking for Jessie flavor for older versions, please speak out aloud and with enough reasons (like if you would like to contribute effort... )

Supported tags and respective Dockerfile links
1. 21.0.3, 21.0, 21, latest (21/Dockerfile)
2. 21.0.3-slim, 21.0-slim, 21-slim, slim (21/slim/Dockerfile)
3. 21.0.3-alpine, 21.0-alpine, 21-alpine, alpine (21/alpine/Dockerfile)
4. 20.3.8.2, 20.3.8, 20.3, 20 (20/Dockerfile)
5. 20.3.8.2-slim, 20.3.8-slim, 20.3-slim, 20-slim (20/slim/Dockerfile)
6. 20.3.8.2-alpine, 20.3.8-alpine, 20.3-alpine, 20-alpine (20/alpine/Dockerfile)
6. 19.3.6.9, 19.3.6, 19.3, 19 (19/Dockerfile)
7. 19.3.6.9-slim, 19.3.6-slim, 19.3-slim, 19-slim (19/slim/Dockerfile)
8. 18.3.4.9, 18.3.4, 18.3, 18 (18/Dockerfile)
9. 18.3.4.9-slim, 18.3.4-slim, 18.3-slim, 18-slim (18/slim/Dockerfile)
9. 17.5.6.9, 17.5.6, 17.5, 17 (17/Dockerfile)
9. 17.5.6.9-slim, 17.5.6-slim, 17.5-slim, 17-slim (17/slim/Dockerfile)
```