### PR TITLE
add erlang/jessie version to the official images

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -71,7 +71,7 @@ for version in "${versions[@]}"; do
 	done
 	versionAliases+=( $version ${aliases[$version]:-} )
 
-	for variant in '' slim alpine; do
+	for variant in '' slim alpine jessie; do
 		dir="$version${variant:+/$variant}"
 		[ -f "$dir/Dockerfile" ] || continue
 


### PR DESCRIPTION
I checked the erlang images yesterday, but not found jessie version in erlang 21 version.
So I add it.