### PR TITLE
bump alpine base to latest: 3.9

### DIFF
--- a/21/alpine/Dockerfile
+++ b/21/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 ENV OTP_VERSION="21.2.4" \
     REBAR3_VERSION="3.8.0"


### PR DESCRIPTION
Note that LibreSSL was replaced with OpenSSL from 3.8 to 3.9.