### PR TITLE
update alpine

### DIFF
--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 ENV OTP_VERSION="20.3.8.20" \
      REBAR3_VERSION="3.9.1"


### PR DESCRIPTION
Try to fix #82 .
docker-library/official-images#5583 fail,  but alpine 3.9 does have arm32v7 architecture, I think this is the reason.
https://github.com/docker-library/official-images/blob/master/library/python#L62-L70 might be help.
I only add erlang-21-alpine for test, it test ok, see the https://travis-ci.org/docker-library/official-images/builds/509306033 