### PR TITLE
setup rebar3 version in build-args instead of hardcoding dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: bash
 services: docker
 
 env:
+  global:
+  - REBAR3_VERSION=3.12.0
+  - REBAR3_DOWNLOAD_SHA256=8ac45498f03e293bc6342ec431888f9a81a4fb9e1177a69965238d127c00a79e
+  matrix:
   - DIR=master
   - DIR=master VARIANT=alpine
   - DIR=22
@@ -25,7 +29,7 @@ before_script:
   - image="erlang:${OTP_VERSION}${VARIANT:+-$VARIANT}"
 
 script:
-    - docker build --pull -t "$image" "${VARIANT:-.}"
+    - docker build --build-arg REBAR3_VERSION=$REBAR3_VERSION --build-arg REBAR3_DOWNLOAD_SHA256=$REBAR3_DOWNLOAD_SHA256 --pull -t "$image" "${VARIANT:-.}"
     - ~/official-images/test/run.sh "$image"
 
 after_script:

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -1,6 +1,11 @@
 FROM buildpack-deps:stretch
 
+ARG REBAR3_VERSION
+ARG REBAR3_DOWNLOAD_SHA256
 ENV OTP_VERSION="18.3.4.11"
+
+LABEL otp.version=$OTP_VERSION
+LABEL rebar3.version=$REBAR3_VERSION
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
@@ -52,11 +57,8 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.7.4"
-
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="3747ef351999caec65304839ecd9324ac8eec8c38210fb43dc598e3caed0a2c0" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -1,6 +1,11 @@
 FROM buildpack-deps:stretch
 
+ARG REBAR3_VERSION
+ARG REBAR3_DOWNLOAD_SHA256
 ENV OTP_VERSION="19.3.6.13"
+
+LABEL otp.version=$OTP_VERSION
+LABEL rebar3.version=$REBAR3_VERSION
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
@@ -52,11 +57,8 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.8.0"
-
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="fc4d08037d39bcc651a4a749f8a5b1a10b2205527df834c2aee8f60725c3f431" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -1,6 +1,11 @@
 FROM buildpack-deps:stretch
 
+ARG REBAR3_VERSION
+ARG REBAR3_DOWNLOAD_SHA256
 ENV OTP_VERSION="20.3.8.22"
+
+LABEL otp.version=$OTP_VERSION
+LABEL rebar3.version=$REBAR3_VERSION
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
@@ -51,11 +56,8 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.10.0"
-
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="656b4a0bd75f340173e67a33c92e4d422b5ccf054f93ba35a9d780b545ee827e" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -1,12 +1,17 @@
-FROM alpine:3.9
+ARG ALPINE_VERSION="3.9"
+FROM alpine:$ALPINE_VERSION
 
-ENV OTP_VERSION="20.3.8.22" \
-     REBAR3_VERSION="3.10.0"
+ARG REBAR3_VERSION
+ARG REBAR3_DOWNLOAD_SHA256
+ENV OTP_VERSION="20.3.8.22"
+
+LABEL otp.version=$OTP_VERSION
+LABEL rebar3.version=$REBAR3_VERSION
+LABEL alpine.version=$ALPINE_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
 	&& OTP_DOWNLOAD_SHA256="d2c36130938659a63d8de094c3d4f8a1d3ea33d4d993d0723ba9c745df2a2753" \
-	&& REBAR3_DOWNLOAD_SHA256="656b4a0bd75f340173e67a33c92e4d422b5ccf054f93ba35a9d780b545ee827e" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \
 		ca-certificates \

--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG ALPINE_VERSION="3.9"
-FROM alpine:$ALPINE_VERSION
+FROM alpine:3.9
 
 ARG REBAR3_VERSION
 ARG REBAR3_DOWNLOAD_SHA256
@@ -7,7 +6,6 @@ ENV OTP_VERSION="20.3.8.22"
 
 LABEL otp.version=$OTP_VERSION
 LABEL rebar3.version=$REBAR3_VERSION
-LABEL alpine.version=$ALPINE_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \

--- a/21/Dockerfile
+++ b/21/Dockerfile
@@ -1,6 +1,11 @@
 FROM buildpack-deps:stretch
 
+ARG REBAR3_VERSION
+ARG REBAR3_DOWNLOAD_SHA256
 ENV OTP_VERSION="21.3.8.6"
+
+LABEL otp.version=$OTP_VERSION
+LABEL rebar3.version=$REBAR3_VERSION
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
@@ -51,11 +56,9 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.11.1"
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="a1822db5210b96b5f8ef10e433b22df19c5fc54dfd847bcaab86c65151ce4171" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/21/alpine/Dockerfile
+++ b/21/alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG ALPINE_VERSION="3.9"
-FROM alpine:$ALPINE_VERSION
+FROM alpine:3.9
 
 ARG REBAR3_VERSION
 ARG REBAR3_DOWNLOAD_SHA256
@@ -7,7 +6,6 @@ ENV OTP_VERSION="21.3.8.6"
 
 LABEL otp.version=$OTP_VERSION
 LABEL rebar3.version=$REBAR3_VERSION
-LABEL alpine.version=$ALPINE_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \

--- a/21/alpine/Dockerfile
+++ b/21/alpine/Dockerfile
@@ -1,12 +1,17 @@
-FROM alpine:3.9
+ARG ALPINE_VERSION="3.9"
+FROM alpine:$ALPINE_VERSION
 
-ENV OTP_VERSION="21.3.8.6" \
-    REBAR3_VERSION="3.11.1"
+ARG REBAR3_VERSION
+ARG REBAR3_DOWNLOAD_SHA256
+ENV OTP_VERSION="21.3.8.6"
+
+LABEL otp.version=$OTP_VERSION
+LABEL rebar3.version=$REBAR3_VERSION
+LABEL alpine.version=$ALPINE_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
 	&& OTP_DOWNLOAD_SHA256="7d96d11143b8ad71448acc0427c2c34756712aa2972d9aaa6d100f87f29918c6" \
-	&& REBAR3_DOWNLOAD_SHA256="a1822db5210b96b5f8ef10e433b22df19c5fc54dfd847bcaab86c65151ce4171" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \
 		ca-certificates \

--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -1,6 +1,11 @@
 FROM buildpack-deps:stretch
 
+ARG REBAR3_VERSION
+ARG REBAR3_DOWNLOAD_SHA256
 ENV OTP_VERSION="22.0.7"
+
+LABEL otp.version=$OTP_VERSION
+LABEL rebar3.version=$REBAR3_VERSION
 
 # We'll install the build dependencies for erlang-odbc along with the erlang
 # build process:
@@ -51,11 +56,8 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.11.1"
-
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="a1822db5210b96b5f8ef10e433b22df19c5fc54dfd847bcaab86c65151ce4171" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/22/alpine/Dockerfile
+++ b/22/alpine/Dockerfile
@@ -1,12 +1,17 @@
-FROM alpine:3.9
+ARG ALPINE_VERSION="3.9"
+FROM alpine:$ALPINE_VERSION
 
-ENV OTP_VERSION="22.0.7" \
-    REBAR3_VERSION="3.11.1"
+ARG REBAR3_VERSION
+ARG REBAR3_DOWNLOAD_SHA256
+ENV OTP_VERSION="22.0.7"
+
+LABEL otp.version=$OTP_VERSION
+LABEL rebar3.version=$REBAR3_VERSION
+LABEL alpine.version=$ALPINE_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
 	&& OTP_DOWNLOAD_SHA256="04c090b55ec4a01778e7e1a5b7fdf54012548ca72737965b7aa8c4d7878c92bc" \
-	&& REBAR3_DOWNLOAD_SHA256="a1822db5210b96b5f8ef10e433b22df19c5fc54dfd847bcaab86c65151ce4171" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \
 		ca-certificates \

--- a/22/alpine/Dockerfile
+++ b/22/alpine/Dockerfile
@@ -1,5 +1,4 @@
-ARG ALPINE_VERSION="3.9"
-FROM alpine:$ALPINE_VERSION
+FROM alpine:3.9
 
 ARG REBAR3_VERSION
 ARG REBAR3_DOWNLOAD_SHA256
@@ -7,7 +6,6 @@ ENV OTP_VERSION="22.0.7"
 
 LABEL otp.version=$OTP_VERSION
 LABEL rebar3.version=$REBAR3_VERSION
-LABEL alpine.version=$ALPINE_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \


### PR DESCRIPTION
This makes it easier to update the rebar3 version by requiring the change in only 1 place.

I can make the change to the other versions, just opening for comment first. it might be something we can do for versions of otp as well.