### PR TITLE
Replace `DEB_BUILD_GNU_TYPE` with `DEB_HOST_GNU_TYPE`.

### DIFF
--- a/17/Dockerfile
+++ b/17/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	&& ./configure --build="$gnuArch" \
 	&& make -j$(nproc) \
 	&& make install \

--- a/17/slim/Dockerfile
+++ b/17/slim/Dockerfile
@@ -32,7 +32,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	&& ./configure --build="$gnuArch" \
 	&& make -j$(nproc) \
 	&& make install \

--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/18/slim/Dockerfile
+++ b/18/slim/Dockerfile
@@ -38,7 +38,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" --enable-sctp \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -24,7 +24,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	&& ./configure --build="$gnuArch" \
 		--enable-dirty-schedulers \
 	&& make -j$(nproc) \

--- a/19/slim/Dockerfile
+++ b/19/slim/Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& cd /usr/src/otp-src \
 	&& ./otp_build autoconf \
-	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	&& ./configure --build="$gnuArch" \
 		--enable-dirty-schedulers \
 	&& make -j$(nproc) \

--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -24,7 +24,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -31,7 +31,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \

--- a/20/slim/Dockerfile
+++ b/20/slim/Dockerfile
@@ -38,7 +38,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/21/Dockerfile
+++ b/21/Dockerfile
@@ -27,7 +27,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/21/alpine/Dockerfile
+++ b/21/alpine/Dockerfile
@@ -33,7 +33,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \

--- a/21/slim/Dockerfile
+++ b/21/slim/Dockerfile
@@ -40,7 +40,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -27,7 +27,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/22/alpine/Dockerfile
+++ b/22/alpine/Dockerfile
@@ -33,7 +33,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \

--- a/22/slim/Dockerfile
+++ b/22/slim/Dockerfile
@@ -40,7 +40,7 @@ RUN set -xe \
 	&& rm otp-src.tar.gz \
 	&& ( cd $ERL_TOP \
 	  && ./otp_build autoconf \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -26,7 +26,7 @@ RUN set -xe \
 	  && ./otp_build autoconf \
 	  && sed -i -e '/utils\/gen_git_version/c\\\
 	@echo GIT_VSN=-DERLANG_GIT_VERSION="\\"\\\\\\""'${OTP_VERSION#*@}'\\\\"\\"\\"" > $@' ./erts/emulator/Makefile.in \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(nproc) \
 	  && make install ) \

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -28,7 +28,7 @@ RUN set -xe \
 	  && ./otp_build autoconf \
 	  && sed -i -e '/utils\/gen_git_version/c\\\
 	@echo GIT_VSN=-DERLANG_GIT_VERSION="\\"\\\\\\""'${OTP_VERSION#*@}'\\\\"\\"\\"" > $@' ./erts/emulator/Makefile.in \
-	  && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
 	  && ./configure --build="$gnuArch" \
 	  && make -j$(getconf _NPROCESSORS_ONLN) \
 	  && make install ) \


### PR DESCRIPTION
From the [CrossBuildPackagingGuidelines wiki page](https://wiki.debian.org/CrossBuildPackagingGuidelines) `DEB_BUILD_GNU_TYPE` is the architecture of the machine *building* the package, whereas `DEB_HOST_GNU_TYPE` is the architecture for which we are building the package.  I noticed this issue while cross-compiling an ARM container on my Mac.