### PR TITLE
Since debian:stretch in now LTS, it no longer supports ppc64le or s390x.

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -86,7 +86,9 @@ for version in "${versions[@]}"; do
 		variantArches=( amd64 arm32v7 arm64v8 i386 s390x ppc64le )
 
 		case "$version" in
-		        19|18) variantArches=( ${variantArches[@]/ppc64le} )
+		    21|20|19|18)
+				variantArches=( ${variantArches[@]/s390x} )
+				variantArches=( ${variantArches[@]/ppc64le} )
 		esac
 
 		echo


### PR DESCRIPTION
see docker-library/official-images#8408