### PR TITLE
append zero string to verion if the verion is two digits

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -39,7 +39,15 @@ extractVersion() {
   awk '
         $1 == "ENV" && /_VERSION/ {
         match($2, /"(.*)"/)
-        print substr($2, RSTART + 1, RLENGTH - 2)
+        versionStr = substr($2, RSTART + 1, RLENGTH - 2)
+        versionStrLength = split(versionStr, versionStrArray, ".")
+        if(versionStrLength > 3) {
+            print versionStr
+        } else if(versionStrLength > 2){
+            print versionStr ".0"
+        } else {
+            print versionStr ".0.0"
+        }
         exit
       }'
 
@@ -59,7 +67,7 @@ for version in "${versions[@]}"; do
 
 	fullVersion="$(git show "$commit":"$version/Dockerfile" | extractVersion)"
 
-	versionAliases=( $fullVersion "immutable-$fullVersion")
+	versionAliases=( $fullVersion )
 	while :; do
 		localVersion="${fullVersion%.*}"
 		if [ "$localVersion" = "$version" ]; then


### PR DESCRIPTION
As in docker-library/official-images#8765 , 
>>>
        WordPress has a similar problem, where they have an X.Y release and then an X.Y.Z later, 
    and we resolve that by padding with zeros so that users can still pin to the "initial release" 
    with X.Y.0 if they so desire to do so.
>>>