### PR TITLE
Aim for the same rebar3 vsn across the board

### DIFF
--- a/19/Dockerfile
+++ b/19/Dockerfile
@@ -52,11 +52,11 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.8.0"
+ENV REBAR3_VERSION="3.14.3"
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="fc4d08037d39bcc651a4a749f8a5b1a10b2205527df834c2aee8f60725c3f431" \
+	&& REBAR3_DOWNLOAD_SHA256="69024b30f17b52c61e5e0568cbf9a2db325eb646ae230c48858401507394f5c0" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/20/Dockerfile
+++ b/20/Dockerfile
@@ -51,11 +51,11 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.13.1"
+ENV REBAR3_VERSION="3.14.3"
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="706cc0770062bde2674abc01964c68553398fe4d8023605b305cfe326b92520f" \
+	&& REBAR3_DOWNLOAD_SHA256="69024b30f17b52c61e5e0568cbf9a2db325eb646ae230c48858401507394f5c0" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/20/alpine/Dockerfile
+++ b/20/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine:3.9
 
 ENV OTP_VERSION="20.3.8.26" \
-     REBAR3_VERSION="3.13.1"
+     REBAR3_VERSION="3.14.3"
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
 	&& OTP_DOWNLOAD_SHA256="dce78b60938a48b887317e5222cff946fd4af36666153ab2f0f022aa91755813" \
-	&& REBAR3_DOWNLOAD_SHA256="706cc0770062bde2674abc01964c68553398fe4d8023605b305cfe326b92520f" \
+	&& REBAR3_DOWNLOAD_SHA256="69024b30f17b52c61e5e0568cbf9a2db325eb646ae230c48858401507394f5c0" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \
 		ca-certificates \

--- a/21/Dockerfile
+++ b/21/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:stretch
 
 ENV OTP_VERSION="21.3.8.18" \
-    REBAR3_VERSION="3.14.1"
+    REBAR3_VERSION="3.14.3"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION
 
@@ -56,7 +56,7 @@ RUN set -xe \
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="b01275b6cbdb354dcf9ed686fce2b5f9dfdd58972ded9e970e31b9215a8521f2" \
+	&& REBAR3_DOWNLOAD_SHA256="69024b30f17b52c61e5e0568cbf9a2db325eb646ae230c48858401507394f5c0" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/21/alpine/Dockerfile
+++ b/21/alpine/Dockerfile
@@ -1,14 +1,14 @@
 FROM alpine:3.9
 
 ENV OTP_VERSION="21.3.8.18" \
-    REBAR3_VERSION="3.14.1"
+    REBAR3_VERSION="3.14.3"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
 	&& OTP_DOWNLOAD_SHA256="3481a47503e1ac0c0296970b460d1936ee0432600f685a216608e04b2f608367" \
-	&& REBAR3_DOWNLOAD_SHA256="b01275b6cbdb354dcf9ed686fce2b5f9dfdd58972ded9e970e31b9215a8521f2" \
+	&& REBAR3_DOWNLOAD_SHA256="69024b30f17b52c61e5e0568cbf9a2db325eb646ae230c48858401507394f5c0" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \
 		ca-certificates \

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Eshell V11.0.3  (abort with ^G)
 "23"
 2> os:getenv().
 ["PROGNAME=erl","ROOTDIR=/usr/local/lib/erlang",
- "TERM=xterm","REBAR3_VERSION=3.13.2","REBAR_VERSION=2.6.4",
+ "TERM=xterm","REBAR3_VERSION=3.14.3","REBAR_VERSION=2.6.4",
  "PWD=/","HOSTNAME=bc9486c9549b","OTP_VERSION=23.0.3",
  "PATH=/usr/local/lib/erlang/erts-11.0.3/bin:/usr/local/lib/erlang/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
- "EMU=beam","HOME=/root", 
+ "EMU=beam","HOME=/root",
  "BINDIR=/usr/local/lib/erlang/erts-11.0.3/bin"]
 3> 'hello_юникод_世界'.                                   % Erlang20 now support unicode in atom
 'hello_юникод_世界'

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -53,11 +53,11 @@ RUN set -xe \
 	&& install -v ./rebar /usr/local/bin/ \
 	&& rm -rf /usr/src/rebar-src
 
-ENV REBAR3_VERSION="3.10.0"
+ENV REBAR3_VERSION="3.14.3"
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="656b4a0bd75f340173e67a33c92e4d422b5ccf054f93ba35a9d780b545ee827e" \
+	&& REBAR3_DOWNLOAD_SHA256="69024b30f17b52c61e5e0568cbf9a2db325eb646ae230c48858401507394f5c0" \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/src/rebar3-src \

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -49,7 +49,7 @@ RUN set -xe \
 
 CMD ["erl"]
 
-ENV REBAR3_VERSION="3.10.0"
+ENV REBAR3_VERSION="3.14.3"
 
 RUN set -xe \
 	&& wget -O /usr/local/bin/rebar3 https://github.com/erlang/rebar3/releases/download/${REBAR3_VERSION}/rebar3 \


### PR DESCRIPTION
My goal here is to remove a variable from potential CI processes.
I've had jobs fail in `erlang:19:3` but not in `erlang:23.1` due to `rebar3` -specific issues (that we're left unsolved in previous versions, but not in the most recent ones).