### PR TITLE
Add alpine LTS builds for OTP 23 and 24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ env:
   - DIR=24
   - DIR=24 VARIANT=slim
   - DIR=24 VARIANT=alpine
+  - DIR=24 VARIANT=alpine-lts
   - DIR=23
   - DIR=23 VARIANT=slim
   - DIR=23 VARIANT=alpine
+  - DIR=23 VARIANT=alpine-lts
   - DIR=22
   - DIR=22 VARIANT=slim
   - DIR=22 VARIANT=alpine

--- a/23/alpine-lts/Dockerfile
+++ b/23/alpine-lts/Dockerfile
@@ -1,0 +1,69 @@
+FROM alpine:3.13
+
+ENV OTP_VERSION="23.3.1" \
+    REBAR3_VERSION="3.14.4"
+
+LABEL org.opencontainers.image.version=$OTP_VERSION
+
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="a5a067a3b17bbef8511f2c056957925b666670b6f2cdaf645e1bc28ce3dd3517" \
+	&& REBAR3_DOWNLOAD_SHA256="8d78ed53209682899d777ee9443b26b39c9bf96c8b081fe94b3dd6693077cb9a" \
+	&& apk add --no-cache --virtual .fetch-deps \
+		curl \
+		ca-certificates \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& apk add --no-cache --virtual .build-deps \
+		--repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main \
+		dpkg-dev dpkg \
+		gcc \
+		g++ \
+		libc-dev \
+		linux-headers=5.4.5-r1 \
+		make \
+		autoconf \
+		ncurses-dev \
+		openssl-dev \
+		unixodbc-dev \
+		lksctp-tools-dev \
+		tar \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp $ERL_TOP \
+	&& tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( cd $ERL_TOP \
+	  && ./otp_build autoconf \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
+	  && ./configure --build="$gnuArch" \
+	  && make -j$(getconf _NPROCESSORS_ONLN) \
+	  && make install ) \
+	&& rm -rf $ERL_TOP \
+	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
+	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
+	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
+	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
+	&& echo "${REBAR3_DOWNLOAD_SHA256}  rebar3-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/src/rebar3-src \
+	&& tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
+	&& rm rebar3-src.tar.gz \
+	&& cd /usr/src/rebar3-src \
+	&& HOME=$PWD ./bootstrap \
+	&& install -v ./rebar3 /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar3-src \
+	&& apk add --virtual .erlang-rundeps \
+		$runDeps \
+		lksctp-tools \
+		ca-certificates \
+	&& apk del .fetch-deps .build-deps
+
+CMD ["erl"]

--- a/24/alpine-lts/Dockerfile
+++ b/24/alpine-lts/Dockerfile
@@ -1,0 +1,69 @@
+FROM alpine:3.13
+
+ENV OTP_VERSION="24.0-rc2" \
+    REBAR3_VERSION="3.14.4"
+
+LABEL org.opencontainers.image.version=$OTP_VERSION
+
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="9eff1b61e3642e7b9f61153c0c067a2aa072e8a187b39770d8145ba11172e526" \
+	&& REBAR3_DOWNLOAD_SHA256="8d78ed53209682899d777ee9443b26b39c9bf96c8b081fe94b3dd6693077cb9a" \
+	&& apk add --no-cache --virtual .fetch-deps \
+		curl \
+		ca-certificates \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& apk add --no-cache --virtual .build-deps \
+		--repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main \
+		dpkg-dev dpkg \
+		gcc \
+		g++ \
+		libc-dev \
+		linux-headers==5.4.5-r1 \
+		make \
+		autoconf \
+		ncurses-dev \
+		openssl-dev \
+		unixodbc-dev \
+		lksctp-tools-dev \
+		tar \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp $ERL_TOP \
+	&& tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( cd $ERL_TOP \
+	  && ./otp_build autoconf \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
+	  && ./configure --build="$gnuArch" \
+	  && make -j$(getconf _NPROCESSORS_ONLN) \
+	  && make install ) \
+	&& rm -rf $ERL_TOP \
+	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
+	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
+	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
+	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
+	&& echo "${REBAR3_DOWNLOAD_SHA256}  rebar3-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/src/rebar3-src \
+	&& tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
+	&& rm rebar3-src.tar.gz \
+	&& cd /usr/src/rebar3-src \
+	&& HOME=$PWD ./bootstrap \
+	&& install -v ./rebar3 /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar3-src \
+	&& apk add --virtual .erlang-rundeps \
+		$runDeps \
+		lksctp-tools \
+		ca-certificates \
+	&& apk del .fetch-deps .build-deps
+
+CMD ["erl"]


### PR DESCRIPTION
With alpine 3.13, the updated kernel headers break SCTP support when the image runs on a host with < 5.5 kernel versions.
To keep SCTP working and benefit from the improvements on alpine 3.13 (e.g. the new musl library), this PR adds alpine-lts image variants using 5.4 kernel headers for building OTP 23 and 24.
This is only useful/necessary until the commonly used LTS distributions on container hosts catch up to kernel version 5.5 or above and for deployments using SCTP.
Would you consider this change to address issue #332 ?