### PR TITLE
Windows containers support

### DIFF
--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -50,9 +50,10 @@ jobs:
           #   * The base image OS version _must_ be the same as the host OS.  Therefore it's
           #     important to include the OS version in the docker tag.
           #   * Nanoserver variants omit huge amounts, so a separate build stage is required.
+          $from_image_name = "${{ matrix.from-image-name }}"
           $from_image_tag = "${{ matrix.from-image-tag }}"
-          $from_image = "mcr.microsoft.com/${{ matrix.from-image-name }}:$from_image_tag"
-          $build_image = "mcr.microsoft.com/${{ matrix.from-image-name }}:$from_image_tag"
+          $from_image = "mcr.microsoft.com/$from_image_name:$from_image_tag"
+          $build_image = "mcr.microsoft.com/$from_image_name:$from_image_tag"
 
           $windows_tag = ($from_image_name.Split("/") + $from_image_tag) -join "-"
           $otp_tag = @($otp_version, $windows_tag) -join "-"

--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -50,8 +50,9 @@ jobs:
           #   * The base image OS version _must_ be the same as the host OS.  Therefore it's
           #     important to include the OS version in the docker tag.
           #   * Nanoserver variants omit huge amounts, so a separate build stage is required.
-          $from_image = "mcr.microsoft.com/${{ matrix.from-image-name }}:${{ matrix.from-image-tag }}"
-          $build_image = "mcr.microsoft.com/${{ matrix.from-image-name }}:${{ matrix.from-image-tag }}"
+          $from_image_tag = "${{ matrix.from-image-tag }}"
+          $from_image = "mcr.microsoft.com/${{ matrix.from-image-name }}:$from_image_tag"
+          $build_image = "mcr.microsoft.com/${{ matrix.from-image-name }}:$from_image_tag"
 
           $windows_tag = ($from_image_name.Split("/") + $from_image_tag) -join "-"
           $otp_tag = @($otp_version, $windows_tag) -join "-"

--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -62,13 +62,18 @@ jobs:
           $otp_tag = @($otp_version, $windows_tag) -join "-"
           $image = "erlang:${otp_tag}"
 
+          $dir = $otp_version.Split(".")[0]
+          $variant = "windows"
+
+          cd $dir
+
           docker build `
             --build-arg "OTP_VERSION=$otp_version" `
             --build-arg "OTP_HASH=$otp_hash" `
             --build-arg "FROM_IMAGE=$from_image" `
             --build-arg "BUILD_IMAGE=$build_image" `
             -t $image `
-            .
+            $variant
 
           # It looks like the official images repo does contain some level of support for testing
           # windows images but I'm not certain how this should be implemented.

--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -55,6 +55,9 @@ jobs:
           $from_image = "mcr.microsoft.com/${from_image_name}:${from_image_tag}"
           $build_image = "mcr.microsoft.com/${from_image_name}:${from_image_tag}"
 
+          $otp_version = "${{ matrix.otp.version }}"
+          $otp_hash = "${{ matrix.otp.hash }}"
+
           $windows_tag = ($from_image_name.Split("/") + $from_image_tag) -join "-"
           $otp_tag = @($otp_version, $windows_tag) -join "-"
           $image = "erlang:${otp_tag}"

--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -27,3 +27,45 @@ jobs:
            docker build --pull -t "$image" "${VARIANT:-.}"
            ~/official-images/test/run.sh "$image"
            docker images
+  docker-win:
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+        from-image-name:
+          - windows
+          - windows/servercore
+        from-image-tag:
+          - "10.0.17763.2114"
+        otp:
+          - version: "24.2"
+            hash: "C22052C4920F06A9044F514A427B1C4116DA6DB6D6D6070EEDEB2955F1F6869B"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          # Windows docker builds must take into account two extra things:
+          #   * The base image OS version _must_ be the same as the host OS.  Therefore it's
+          #     important to include the OS version in the docker tag.
+          #   * Nanoserver variants omit huge amounts, so a separate build stage is required.
+          $from_image = "mcr.microsoft.com/${{ matrix.from-image-name }}:${{ matrix.from-image-tag }}"
+          $build_image = "mcr.microsoft.com/${{ matrix.from-image-name }}:${{ matrix.from-image-tag }}"
+
+          $windows_tag = ($from_image_name.Split("/") + $from_image_tag) -join "-"
+          $otp_tag = @($otp_version, $windows_tag) -join "-"
+          $image= "erlang:${otp_tag}"
+
+          docker build `
+            --build-arg "OTP_VERSION=$otp_version" `
+            --build-arg "OTP_HASH=$otp_hash" `
+            --build-arg "FROM_IMAGE=$from_image" `
+            --build-arg "BUILD_IMAGE=$build_image" `
+            -t $image `
+            .
+
+          # It looks like the official images repo does contain some level of support for testing
+          # windows images but I'm not certain how this should be implemented.
+
+          docker images

--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -53,7 +53,7 @@ jobs:
           $from_image_name = "${{ matrix.from-image-name }}"
           $from_image_tag = "${{ matrix.from-image-tag }}"
           $from_image = "mcr.microsoft.com/${from_image_name}:${from_image_tag}"
-          $build_image = "mcr.microsoft.com/${from_image_name}:${from_image_tag}"
+          $build_image = "mcr.microsoft.com/windows:${from_image_tag}"
 
           $otp_version = "${{ matrix.otp.version }}"
           $otp_hash = "${{ matrix.otp.hash }}"

--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -57,7 +57,7 @@ jobs:
 
           $windows_tag = ($from_image_name.Split("/") + $from_image_tag) -join "-"
           $otp_tag = @($otp_version, $windows_tag) -join "-"
-          $image= "erlang:${otp_tag}"
+          $image = "erlang:${otp_tag}"
 
           docker build `
             --build-arg "OTP_VERSION=$otp_version" `

--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -52,8 +52,8 @@ jobs:
           #   * Nanoserver variants omit huge amounts, so a separate build stage is required.
           $from_image_name = "${{ matrix.from-image-name }}"
           $from_image_tag = "${{ matrix.from-image-tag }}"
-          $from_image = "mcr.microsoft.com/$from_image_name:$from_image_tag"
-          $build_image = "mcr.microsoft.com/$from_image_name:$from_image_tag"
+          $from_image = "mcr.microsoft.com/${from_image_name}:${from_image_tag}"
+          $build_image = "mcr.microsoft.com/${from_image_name}:${from_image_tag}"
 
           $windows_tag = ($from_image_name.Split("/") + $from_image_tag) -join "-"
           $otp_tag = @($otp_version, $windows_tag) -join "-"

--- a/24/windows/Dockerfile
+++ b/24/windows/Dockerfile
@@ -1,3 +1,5 @@
+# Use a separate build and distribution base image because some variants of Windows (i.e.
+# nanoserver) don't include the necessary dependencies to run the installer)
 ARG BUILD_IMAGE=mcr.microsoft.com/windows:10.0.17763.2114
 ARG FROM_IMAGE=${BUILD_IMAGE}
 
@@ -11,23 +13,22 @@ ARG OTP_HASH
 
 ADD https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_win64_${OTP_VERSION}.exe ./otp-installer.exe
 
+# Check installer integrity
 RUN if ((Get-FileHash ".\otp-installer.exe" -Algorithm SHA256).Hash -ne $Env:OTP_HASH) { exit 1; }
 
 FROM $FROM_IMAGE
 
 ARG OTP_VERSION
 
-# run OTP installer in this image, copying Program Files over doesn't work
 COPY --from=build ["C:/otp-installer.exe", "C:/otp-installer.exe"]
 
+# Run and cleanup the installer
 RUN .\otp-installer.exe /S /w /v"/qn"; \
   del /f .\otp-installer.exe
 
 # This is a workaround for nanoserver where not possible to set PATH using setx or similar
 ENV PATH="C:\Windows\system32;C:\Windows;C:/Program Files/erl-${OTP_VERSION}/bin"
 
-# Some failed attempts below; someone could fix these!
-# RUN setx /M PATH "%PATH%;%ProgramFiles%\erl-%OTP_VERSION%\bin"
-# RUN setx /M PATH $($Env:PATH + ';C:\Program Files\erl-' + $Env:OTP_VERSION + '\bin')
-
+# werl.exe isn't suitable here so we just use plain erl.exe; see
+# https://www.erlang.org/doc/man/werl.html
 CMD [ "erl.exe" ]

--- a/24/windows/Dockerfile
+++ b/24/windows/Dockerfile
@@ -1,0 +1,33 @@
+ARG BUILD_IMAGE=mcr.microsoft.com/windows:10.0.17763.2114
+ARG FROM_IMAGE=${BUILD_IMAGE}
+
+FROM $BUILD_IMAGE as build
+
+# Use powershell, fail fast on errors
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ARG OTP_VERSION
+ARG OTP_HASH
+
+ADD https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_win64_${OTP_VERSION}.exe ./otp-installer.exe
+
+RUN if ((Get-FileHash ".\otp-installer.exe" -Algorithm SHA256).Hash -ne $Env:OTP_HASH) { exit 1; }
+
+FROM $FROM_IMAGE
+
+ARG OTP_VERSION
+
+# run OTP installer in this image, copying Program Files over doesn't work
+COPY --from=build ["C:/otp-installer.exe", "C:/otp-installer.exe"]
+
+RUN .\otp-installer.exe /S /w /v"/qn"; \
+  del /f .\otp-installer.exe
+
+# This is a workaround for nanoserver where not possible to set PATH using setx or similar
+ENV PATH="C:\Windows\system32;C:\Windows;C:/Program Files/erl-${OTP_VERSION}/bin"
+
+# Some failed attempts below; someone could fix these!
+# RUN setx /M PATH "%PATH%;%ProgramFiles%\erl-%OTP_VERSION%\bin"
+# RUN setx /M PATH $($Env:PATH + ';C:\Program Files\erl-' + $Env:OTP_VERSION + '\bin')
+
+CMD [ "erl.exe" ]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Build Status](https://github.com/erlang/docker-erlang-otp/workflows/erlang/badge.svg)](https://github.com/erlang/docker-erlang-otp/actions)
 
 This is used as docker base image for Erlang OTP.
-The goal is to provide images for a few last erlang releases (currently 24 / 23 / 22 / 21 / 20 / 19 / 18), in close to full feature Erlang OTP, and relatively slim images. Support to 17, R16 and R15 are provided in this repo on a best-effort basis, and not part of official-image effort in docker-library/official-images#1075 .
+The goal is to provide images for a few last erlang releases (currently 24 / 23 / 22 / 21 / 20 / 19 / 18), in close to full feature Erlang OTP, and relatively slim images. Support to 17, R16 and R15 are provided in this repo on a best-effort basis, and not part of official-image effort in docker-library/official-images#1075 .  Windows container based images are available for OTP 24 + with `windows` and `windows/servercore` base images (`windows/nanoserver` is not yet supported).
 
 ### use the Erlang 23
 
@@ -88,6 +88,7 @@ Read from https://github.com/erlang/otp/releases for each tag description as rel
 3. the slim version is built from `debian:buster` install building tools (compilers & -dev packages) on the fly and uninstall after compilation finished, to shrink image size;
 4. the alpine version is built from last alpine stable image, install building tools (compilers & -dev packages) on the fly and uninstall after compilation finished, also removed src/\*.erl include/\*.hrl / all docs (include man info) / examples / static archives / build and unittest tools, and strip the ELF binaries, to get a really slim image, ideally smaller than 20MB;
 5. rebar and rebar3 tool is bundled in `erlang:23`, `erlang:22`, `erlang:21`, `erlang:20`, `erlang:19` and `erlang:18` image;
+6. Windows variants are not built and instead are sourced from the official Windows installer.  Images are tagged with the Windows base image name and operating system version, since the container OS and host OS versions must match when using Windows containers.
 
 ### Sizes
 


### PR DESCRIPTION
Adds support for Windows containers (as proposed in #360 ).

Unlike Linux-flavoured containers, Windows insists that a containers base OS and host OS version must match precisely.  Therefore I've added both the Windows image name and tag into the tagged Erlang images.  In practice, a mismatched host + container OS _may_ work but be prepared for sudden and rather cryptic failures.  Microsoft does appear to be actively improving this situation so perhaps this may become a thing of the past eventually.

I've picked a Windows base image version of `10.0.17763.2114` because that's the current version of Windows in Azure Kubernetes Service, in anticipation that this will be the correct version for most users at the time of writing.  Adding more base images should be simply a case of adding to the actions `matrix`.

Things that are missing:

* In the original Linux build action a test suite from  https://github.com/docker-library/official-images.git is run.  It looks like there is some support for windows containers here but I'm not sure how this should be implemented.
* `windows/nanoserver` support is not present.  Adding support would be a case of figuring out what missing dependencies there are for both the installer and Erlang/OTP itself, and adding them into the `nanoserver` image at build time.  This is tedious work but the bonus would be a much reduced image size.  I suggest leaving this as a separate matter for a future MR.

