### PR TITLE
Suggestion to add image  variants with jit disabled for otp 24 and 25

### DIFF
--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         otp: ['DIR=master', 'DIR=master VARIANT=alpine',
-              'DIR=25', 'DIR=25 VARIANT=slim', 'DIR=25 VARIANT=alpine',
-              'DIR=24', 'DIR=24 VARIANT=slim', 'DIR=24 VARIANT=alpine',
+              'DIR=25', 'DIR=25 VARIANT=slim', 'DIR=25 VARIANT=alpine', 'DIR=25 VARIANT=no-jit',
+              'DIR=24', 'DIR=24 VARIANT=slim', 'DIR=24 VARIANT=alpine', 'DIR=24 VARIANT=no-jit',
               'DIR=23',' DIR=23 VARIANT=slim', 'DIR=23 VARIANT=alpine',
               'DIR=22', 'DIR=22 VARIANT=slim', 'DIR=22 VARIANT=alpine',
               'DIR=21', 'DIR=21 VARIANT=slim', 'DIR=21 VARIANT=alpine',

--- a/24/no-jit/Dockerfile
+++ b/24/no-jit/Dockerfile
@@ -1,0 +1,69 @@
+FROM buildpack-deps:bullseye
+
+ENV OTP_VERSION="24.2.2" \
+    REBAR3_VERSION="3.18.0"
+
+LABEL org.opencontainers.image.version=$OTP_VERSION
+
+# We'll install the build dependencies for erlang-odbc along with the erlang
+# build process:
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="b6adfc0bf14d94348146ae26cc38d09dca545f8e14ebab7ddcf9482a6e8d1162" \
+	&& runtimeDeps='libodbc1 \
+			libsctp1 \
+			libwxgtk3.0' \
+	&& buildDeps='unixodbc-dev \
+			libsctp-dev \
+			libwxgtk-webview3.0-gtk3-dev' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $runtimeDeps \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp $ERL_TOP \
+	&& tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( cd $ERL_TOP \
+	  && ./otp_build autoconf \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
+	  && ./configure --disable-jit --build="$gnuArch" \
+	  && make -j$(nproc) \
+	  && make -j$(nproc) docs DOC_TARGETS=chunks \
+	  && make install install-docs DOC_TARGETS=chunks ) \
+	&& find /usr/local -name examples | xargs rm -rf \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf $ERL_TOP /var/lib/apt/lists/*
+
+CMD ["erl"]
+
+# extra useful tools here: rebar & rebar3
+
+ENV REBAR_VERSION="2.6.4"
+
+RUN set -xe \
+	&& REBAR_DOWNLOAD_URL="https://github.com/rebar/rebar/archive/${REBAR_VERSION}.tar.gz" \
+	&& REBAR_DOWNLOAD_SHA256="577246bafa2eb2b2c3f1d0c157408650446884555bf87901508ce71d5cc0bd07" \
+	&& mkdir -p /usr/src/rebar-src \
+	&& curl -fSL -o rebar-src.tar.gz "$REBAR_DOWNLOAD_URL" \
+	&& echo "$REBAR_DOWNLOAD_SHA256 rebar-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar-src.tar.gz -C /usr/src/rebar-src --strip-components=1 \
+	&& rm rebar-src.tar.gz \
+	&& cd /usr/src/rebar-src \
+	&& ./bootstrap \
+	&& install -v ./rebar /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar-src
+
+RUN set -xe \
+	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+	&& REBAR3_DOWNLOAD_SHA256="cce1925d33240d81d0e4d2de2eef3616d4c17b0532ed004274f875e6607d25d2" \
+	&& mkdir -p /usr/src/rebar3-src \
+	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
+	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
+	&& rm rebar3-src.tar.gz \
+	&& cd /usr/src/rebar3-src \
+	&& HOME=$PWD ./bootstrap \
+	&& install -v ./rebar3 /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar3-src

--- a/25/no-jit/Dockerfile
+++ b/25/no-jit/Dockerfile
@@ -1,0 +1,69 @@
+FROM buildpack-deps:bullseye
+
+ENV OTP_VERSION="25.0-rc1" \
+    REBAR3_VERSION="3.18.0"
+
+LABEL org.opencontainers.image.version=$OTP_VERSION
+
+# We'll install the build dependencies for erlang-odbc along with the erlang
+# build process:
+RUN set -xe \
+	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
+	&& OTP_DOWNLOAD_SHA256="dd3b32d360d1b4c9533a3e51e782c424aaffaeed44520aac8fe9dbd5571a041b" \
+	&& runtimeDeps='libodbc1 \
+			libsctp1 \
+			libwxgtk3.0' \
+	&& buildDeps='unixodbc-dev \
+			libsctp-dev \
+			libwxgtk-webview3.0-gtk3-dev' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $runtimeDeps \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
+	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
+	&& export ERL_TOP="/usr/src/otp_src_${OTP_VERSION%%@*}" \
+	&& mkdir -vp $ERL_TOP \
+	&& tar -xzf otp-src.tar.gz -C $ERL_TOP --strip-components=1 \
+	&& rm otp-src.tar.gz \
+	&& ( cd $ERL_TOP \
+	  && ./otp_build autoconf \
+	  && gnuArch="$(dpkg-architecture --query DEB_HOST_GNU_TYPE)" \
+	  && ./configure --disable-jit --build="$gnuArch" \
+	  && make -j$(nproc) \
+	  && make -j$(nproc) docs DOC_TARGETS=chunks \
+	  && make install install-docs DOC_TARGETS=chunks ) \
+	&& find /usr/local -name examples | xargs rm -rf \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf $ERL_TOP /var/lib/apt/lists/*
+
+CMD ["erl"]
+
+# extra useful tools here: rebar & rebar3
+
+ENV REBAR_VERSION="2.6.4"
+
+RUN set -xe \
+	&& REBAR_DOWNLOAD_URL="https://github.com/rebar/rebar/archive/${REBAR_VERSION}.tar.gz" \
+	&& REBAR_DOWNLOAD_SHA256="577246bafa2eb2b2c3f1d0c157408650446884555bf87901508ce71d5cc0bd07" \
+	&& mkdir -p /usr/src/rebar-src \
+	&& curl -fSL -o rebar-src.tar.gz "$REBAR_DOWNLOAD_URL" \
+	&& echo "$REBAR_DOWNLOAD_SHA256 rebar-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar-src.tar.gz -C /usr/src/rebar-src --strip-components=1 \
+	&& rm rebar-src.tar.gz \
+	&& cd /usr/src/rebar-src \
+	&& ./bootstrap \
+	&& install -v ./rebar /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar-src
+
+RUN set -xe \
+	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
+	&& REBAR3_DOWNLOAD_SHA256="cce1925d33240d81d0e4d2de2eef3616d4c17b0532ed004274f875e6607d25d2" \
+	&& mkdir -p /usr/src/rebar3-src \
+	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
+	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \
+	&& tar -xzf rebar3-src.tar.gz -C /usr/src/rebar3-src --strip-components=1 \
+	&& rm rebar3-src.tar.gz \
+	&& cd /usr/src/rebar3-src \
+	&& HOME=$PWD ./bootstrap \
+	&& install -v ./rebar3 /usr/local/bin/ \
+	&& rm -rf /usr/src/rebar3-src


### PR DESCRIPTION
When building multi architecture images using buildx and either of the otp 24 or otp 25 images, the buildx build process crashes because qemu gets a segmentation fault.

The problem seem to be a compatibility issue with the erlang jit compiler introduced from otp 24. See [https://github.com/erlang/otp/issues/5625]() and [https://elixirforum.com/t/building-elixir-erlang-linux-amd64-application-image-on-apple-silicon/43913]() for some information on the issue.

To workaround the issue I copied the Dockerfiles for otp 24 and added the `--disable-jit` option and built an image. Then I tried to do a buildx multiarchitecture (linux/amd64 and linux/arm64) build using the `no-jit` variant and it worked just fine. :)

Building the `erlang:24-no-jit` image took a really long time for the architecture that was build on emulated cpu (>3100s)(M1 pro), so it would be a great service to anyone needing to workaround the qemu/jit incompatibility to have an official `erlang:24-no-jit`-image available for the docker hub.

I hope that you too will find the variants a welcome addition to the official images.




