### PR TITLE
Update Alpine (3.17)

### DIFF
--- a/.github/workflows/erlang.yaml
+++ b/.github/workflows/erlang.yaml
@@ -1,6 +1,6 @@
 name: erlang
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   docker:
@@ -11,13 +11,13 @@ jobs:
               'DIR=26', 'DIR=26 VARIANT=slim', 'DIR=26 VARIANT=alpine',
               'DIR=25', 'DIR=25 VARIANT=slim', 'DIR=25 VARIANT=alpine',
               'DIR=24', 'DIR=24 VARIANT=slim', 'DIR=24 VARIANT=alpine',
-              'DIR=23',' DIR=23 VARIANT=slim', 'DIR=23 VARIANT=alpine',
+              'DIR=23', 'DIR=23 VARIANT=slim', 'DIR=23 VARIANT=alpine',
               'DIR=22', 'DIR=22 VARIANT=slim', 'DIR=22 VARIANT=alpine',
               'DIR=21', 'DIR=21 VARIANT=slim',
               'DIR=20', 'DIR=20 VARIANT=slim']
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: |
            ${{ matrix.otp }}

--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 ENV OTP_VERSION="24.3.4.7" \
     REBAR3_VERSION="3.19.0"

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.17
 
 ENV OTP_VERSION="25.2.3" \
     REBAR3_VERSION="3.19.0"


### PR DESCRIPTION
Alpine 3.17 has been [released at the end of 2022](https://alpinelinux.org/posts/Alpine-3.17.0-released.html). Notable highlights from the changelog:

  * GCC 12
  * LLVM 15
  * OpenSSL 3.0 (!)
  * PostgreSQL 15
  * ...

The most significant change is that OpenSSL 3.0 is the default now. OpenSSL 1.1 is available via the `openssl1.1-compat` package.

Furthermore, the update includes some other useful new libraries (e.g. `vips-heif`).

During my tests there were problems with Erlang 22 and 23 using OpenSSL 3.0. Compilations failed and the compatibility package mentioned above did not help. Therefore I left 22 and 23 on Alpine Linux 3.16, while 24 and 25 seem to work fine on 3.17.

Additional changes in this PR:

  * In GitHub Actions use `actions/checkout@v3` (v2 has been deprecated).
  * Add the `workflow_dispatch` setting to the GitHub Action. When forking this repo, action runs are disabled by default. When a contributor pushes new code to his/her fork, the "erlang" action is not run. This change allows to manually trigger a run after enabling actions in the forked repo without having to push a new commit.

Looking forward to comments for my first PR here 😀
