### PR TITLE
alpine 3.18 for OTP 25

### DIFF
--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 
 ENV OTP_VERSION="25.3.2.8" \
     REBAR3_VERSION="3.20.0"


### PR DESCRIPTION
As updated in https://github.com/erlang/docker-erlang-otp/pull/443 for OTP 26, this PR updates OTP 25 to alpine 3.18.

I'm open to create a separate folder for alpine 3.18/3.19 if it helps in order to create different tags and avoid backwards incompatibility. Let me know.