### PR TITLE
Use Rebar3 3.18.0 for OTP 22

### DIFF
--- a/22/Dockerfile
+++ b/22/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:buster
 
 ENV OTP_VERSION="22.3.4.27" \
-    REBAR3_VERSION="3.20.0" \
+    REBAR3_VERSION="3.18.0" \
     REBAR_VERSION="2.6.4"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION
@@ -55,7 +55,7 @@ RUN set -xe \
 
 RUN set -xe \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="53ed7f294a8b8fb4d7d75988c69194943831c104d39832a1fa30307b1a8593de" \
+	&& REBAR3_DOWNLOAD_SHA256="cce1925d33240d81d0e4d2de2eef3616d4c17b0532ed004274f875e6607d25d2" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \

--- a/22/slim/Dockerfile
+++ b/22/slim/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster
 
 ENV OTP_VERSION="22.3.4.27" \
-    REBAR3_VERSION="3.20.0"
+    REBAR3_VERSION="3.18.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION
 
@@ -47,7 +47,7 @@ RUN set -xe \
 	  && make install ) \
 	&& find /usr/local -name examples | xargs rm -rf \
 	&& REBAR3_DOWNLOAD_URL="https://github.com/erlang/rebar3/archive/${REBAR3_VERSION}.tar.gz" \
-	&& REBAR3_DOWNLOAD_SHA256="53ed7f294a8b8fb4d7d75988c69194943831c104d39832a1fa30307b1a8593de" \
+	&& REBAR3_DOWNLOAD_SHA256="cce1925d33240d81d0e4d2de2eef3616d4c17b0532ed004274f875e6607d25d2" \
 	&& mkdir -p /usr/src/rebar3-src \
 	&& curl -fSL -o rebar3-src.tar.gz "$REBAR3_DOWNLOAD_URL" \
 	&& echo "$REBAR3_DOWNLOAD_SHA256 rebar3-src.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
Starting from 3.19.0, Rebar3 only support OTP 23 to 25 inclusively. Hence, the last official supported Rebar3 for OTP 22 is 3.18.0.

See:
- https://github.com/erlang/rebar3/releases/tag/3.19.0
- https://github.com/erlang/rebar3/pull/2706