### PR TITLE
make SCTP in images work older Linux kernels

### DIFF
--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -15,11 +15,12 @@ RUN set -xe \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& apk add --no-cache --virtual .build-deps \
+		   --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main \
 		dpkg-dev dpkg \
 		gcc \
 		g++ \
 		libc-dev \
-		linux-headers \
+		linux-headers=5.4.5-r1 \
 		make \
 		autoconf \
 		ncurses-dev \

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -15,11 +15,12 @@ RUN set -xe \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& apk add --no-cache --virtual .build-deps \
+		   --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main \
 		dpkg-dev dpkg \
 		gcc \
 		g++ \
 		libc-dev \
-		linux-headers \
+		linux-headers=5.4.5-r1 \
 		make \
 		autoconf \
 		ncurses-dev \

--- a/26/alpine/Dockerfile
+++ b/26/alpine/Dockerfile
@@ -15,11 +15,12 @@ RUN set -xe \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& apk add --no-cache --virtual .build-deps \
+		   --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main \
 		dpkg-dev dpkg \
 		gcc \
 		g++ \
 		libc-dev \
-		linux-headers \
+		linux-headers=5.4.5-r1 \
 		make \
 		autoconf \
 		ncurses-dev \

--- a/27/alpine/Dockerfile
+++ b/27/alpine/Dockerfile
@@ -15,11 +15,12 @@ RUN set -xe \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& apk add --no-cache --virtual .build-deps \
+		   --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main \
 		dpkg-dev dpkg \
 		gcc \
 		g++ \
 		libc-dev \
-		linux-headers \
+		linux-headers=5.4.5-r1 \
 		make \
 		autoconf \
 		ncurses-dev \

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -15,11 +15,12 @@ RUN set -xe \
 	&& curl -fSL -o otp-src.tar.gz "$OTP_DOWNLOAD_URL" \
 	&& echo "$OTP_DOWNLOAD_SHA256  otp-src.tar.gz" | sha256sum -c - \
 	&& apk add --no-cache --virtual .build-deps \
+		   --repository=http://dl-cdn.alpinelinux.org/alpine/v3.12/main \
 		dpkg-dev dpkg \
 		gcc \
 		g++ \
 		libc-dev \
-		linux-headers \
+		linux-headers=5.4.5-r1 \
 		make \
 		autoconf \
 		ncurses-dev \


### PR DESCRIPTION
Linux SCTP ioctl argument length checking is not forward compatible with newer kernel headers.

The length of the SCTP ioctl argument is based on the size of some SCTP structs. If code compiled with newer kernel headers, where the SCTP structs are larger, is running on an older kernel and tries to pass an SCTP struct that is larger than what the running kernel supports, then the ioctl results in an error.

Erlang's SCTP code does exactly that. This means that SCTP in an Erlang VM that has been compiled with recent kernel headers will not work on older kernels.

This change pulls in Linux 5.4.5 kernel headers (and only the kernel headers) from Alpine 3.12. The resulting images will have working SCTP support when running on Linux 5.4.5 and newer.

Replacement for the outdated #336, fixes #332