### PR TITLE
roll back to alpine 3.20, as erts/configure does not detect poll() co…

### DIFF
--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.20
 
 ENV OTP_VERSION="24.3.4.17" \
     REBAR3_VERSION="3.23.0"

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.20
 
 ENV OTP_VERSION="25.3.2.16" \
     REBAR3_VERSION="3.24.0"

--- a/26/alpine/Dockerfile
+++ b/26/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.20
 
 ENV OTP_VERSION="26.2.5.6" \
     REBAR3_VERSION="3.24.0"

--- a/27/alpine/Dockerfile
+++ b/27/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.20
 
 ENV OTP_VERSION="27.2" \
     REBAR3_VERSION="3.24.0"


### PR DESCRIPTION
…rrectly when gcc 14 is used

also see https://github.com/erlang/otp/issues/9211
some other discussion here
https://github.com/docker-library/official-images/pull/18183

also @mkonrad ， as https://github.com/erlang/docker-erlang-otp/pull/488 is roll back