### PR TITLE
bump otp versions

### DIFF
--- a/25/Dockerfile
+++ b/25/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="15467c6da67f7f4cdbbbd478322c96b370c8d41b82f4b813dbfd8ebc87d4677f" \
+	&& OTP_DOWNLOAD_SHA256="9dda848291428c02d8373f32da5dabf7c1a1478d9cba268fa85475eb26371fe7" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1 \
 			libwxgtk3.0 \

--- a/25/Dockerfile
+++ b/25/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:bullseye
 
-ENV OTP_VERSION="25.3.2.16" \
+ENV OTP_VERSION="25.3.2.20" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/25/Dockerfile
+++ b/25/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="9dda848291428c02d8373f32da5dabf7c1a1478d9cba268fa85475eb26371fe7" \
+	&& OTP_DOWNLOAD_SHA256="513bd9d2fc9c792984314feead5d971bb19e6ee531b4e208d4d4fd30774523f6" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1 \
 			libwxgtk3.0 \

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-ENV OTP_VERSION="25.3.2.16" \
+ENV OTP_VERSION="25.3.2.20" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="15467c6da67f7f4cdbbbd478322c96b370c8d41b82f4b813dbfd8ebc87d4677f" \
+	&& OTP_DOWNLOAD_SHA256="9dda848291428c02d8373f32da5dabf7c1a1478d9cba268fa85475eb26371fe7" \
 	&& REBAR3_DOWNLOAD_SHA256="391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="9dda848291428c02d8373f32da5dabf7c1a1478d9cba268fa85475eb26371fe7" \
+	&& OTP_DOWNLOAD_SHA256="513bd9d2fc9c792984314feead5d971bb19e6ee531b4e208d4d4fd30774523f6" \
 	&& REBAR3_DOWNLOAD_SHA256="391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \

--- a/25/slim/Dockerfile
+++ b/25/slim/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # sure our final image contains only what we've just built:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="9dda848291428c02d8373f32da5dabf7c1a1478d9cba268fa85475eb26371fe7" \
+	&& OTP_DOWNLOAD_SHA256="513bd9d2fc9c792984314feead5d971bb19e6ee531b4e208d4d4fd30774523f6" \
 	&& fetchDeps=' \
 		curl \
 		ca-certificates' \

--- a/25/slim/Dockerfile
+++ b/25/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ENV OTP_VERSION="25.3.2.16" \
+ENV OTP_VERSION="25.3.2.20" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/25/slim/Dockerfile
+++ b/25/slim/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # sure our final image contains only what we've just built:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="15467c6da67f7f4cdbbbd478322c96b370c8d41b82f4b813dbfd8ebc87d4677f" \
+	&& OTP_DOWNLOAD_SHA256="9dda848291428c02d8373f32da5dabf7c1a1478d9cba268fa85475eb26371fe7" \
 	&& fetchDeps=' \
 		curl \
 		ca-certificates' \

--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:bookworm
 
-ENV OTP_VERSION="26.2.5.6" \
+ENV OTP_VERSION="26.2.5.11" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="69cf6c2cc4e54e8d0bab8f9893f0b61dee10bff575c3535d47b6057a468751b1" \
+	&& OTP_DOWNLOAD_SHA256="2eef7aac690a6cedfe0e6a20fc2d700db3490b4e4249683c0e5b812ad71304ed" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1 \
 			libwxgtk3.2-1 \

--- a/26/Dockerfile
+++ b/26/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="371e59b98de59822e45fdbe50c18c8d8dd4c872990e7aaaba8a819e167186d03" \
+	&& OTP_DOWNLOAD_SHA256="69cf6c2cc4e54e8d0bab8f9893f0b61dee10bff575c3535d47b6057a468751b1" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1 \
 			libwxgtk3.2-1 \

--- a/26/alpine/Dockerfile
+++ b/26/alpine/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="69cf6c2cc4e54e8d0bab8f9893f0b61dee10bff575c3535d47b6057a468751b1" \
+	&& OTP_DOWNLOAD_SHA256="2eef7aac690a6cedfe0e6a20fc2d700db3490b4e4249683c0e5b812ad71304ed" \
 	&& REBAR3_DOWNLOAD_SHA256="391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \

--- a/26/alpine/Dockerfile
+++ b/26/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20
 
-ENV OTP_VERSION="26.2.5.6" \
+ENV OTP_VERSION="26.2.5.11" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/26/alpine/Dockerfile
+++ b/26/alpine/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="371e59b98de59822e45fdbe50c18c8d8dd4c872990e7aaaba8a819e167186d03" \
+	&& OTP_DOWNLOAD_SHA256="69cf6c2cc4e54e8d0bab8f9893f0b61dee10bff575c3535d47b6057a468751b1" \
 	&& REBAR3_DOWNLOAD_SHA256="391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \

--- a/26/slim/Dockerfile
+++ b/26/slim/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # sure our final image contains only what we've just built:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="371e59b98de59822e45fdbe50c18c8d8dd4c872990e7aaaba8a819e167186d03" \
+	&& OTP_DOWNLOAD_SHA256="69cf6c2cc4e54e8d0bab8f9893f0b61dee10bff575c3535d47b6057a468751b1" \
 	&& fetchDeps=' \
 		curl \
 		ca-certificates' \

--- a/26/slim/Dockerfile
+++ b/26/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 
-ENV OTP_VERSION="26.2.5.6" \
+ENV OTP_VERSION="26.2.5.11" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/26/slim/Dockerfile
+++ b/26/slim/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # sure our final image contains only what we've just built:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/archive/OTP-${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="69cf6c2cc4e54e8d0bab8f9893f0b61dee10bff575c3535d47b6057a468751b1" \
+	&& OTP_DOWNLOAD_SHA256="2eef7aac690a6cedfe0e6a20fc2d700db3490b4e4249683c0e5b812ad71304ed" \
 	&& fetchDeps=' \
 		curl \
 		ca-certificates' \

--- a/27/Dockerfile
+++ b/27/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # build process:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_src_${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="7997a0900d149c82ae3d0f523d7dfa960ac3cd58acf0b158519c108eb5c65661" \
+	&& OTP_DOWNLOAD_SHA256="5c5c69c7816c97e33f7f8efaab44b4465dc62365f5a60a7fb2a132f6e116748e" \
 	&& runtimeDeps='libodbc1 \
 			libsctp1 \
 			libwxgtk3.2 \

--- a/27/Dockerfile
+++ b/27/Dockerfile
@@ -1,6 +1,6 @@
 FROM buildpack-deps:bookworm
 
-ENV OTP_VERSION="27.3.2" \
+ENV OTP_VERSION="27.3.3" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/27/alpine/Dockerfile
+++ b/27/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.21
 
-ENV OTP_VERSION="27.3.2" \
+ENV OTP_VERSION="27.3.3" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/27/alpine/Dockerfile
+++ b/27/alpine/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_src_${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="7997a0900d149c82ae3d0f523d7dfa960ac3cd58acf0b158519c108eb5c65661" \
+	&& OTP_DOWNLOAD_SHA256="5c5c69c7816c97e33f7f8efaab44b4465dc62365f5a60a7fb2a132f6e116748e" \
 	&& REBAR3_DOWNLOAD_SHA256="391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c" \
 	&& apk add --no-cache --virtual .fetch-deps \
 		curl \

--- a/27/slim/Dockerfile
+++ b/27/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 
-ENV OTP_VERSION="27.3.2" \
+ENV OTP_VERSION="27.3.3" \
     REBAR3_VERSION="3.24.0"
 
 LABEL org.opencontainers.image.version=$OTP_VERSION

--- a/27/slim/Dockerfile
+++ b/27/slim/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.version=$OTP_VERSION
 # sure our final image contains only what we've just built:
 RUN set -xe \
 	&& OTP_DOWNLOAD_URL="https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_src_${OTP_VERSION}.tar.gz" \
-	&& OTP_DOWNLOAD_SHA256="7997a0900d149c82ae3d0f523d7dfa960ac3cd58acf0b158519c108eb5c65661" \
+	&& OTP_DOWNLOAD_SHA256="5c5c69c7816c97e33f7f8efaab44b4465dc62365f5a60a7fb2a132f6e116748e" \
 	&& fetchDeps=' \
 		curl \
 		ca-certificates' \


### PR DESCRIPTION
re: https://github.com/erlang/otp/security/advisories/GHSA-37cp-fgq5-7wc2

this patches official erlang docker images 