### PR TITLE
Fix operator precedence between `&&` and `||`

### DIFF
--- a/24/alpine/Dockerfile
+++ b/24/alpine/Dockerfile
@@ -39,8 +39,8 @@ RUN set -xe \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
 	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
-	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
-	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& { find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true; } \
+	&& { find /usr/local -name src | xargs -r find | xargs rmdir -vp || true; } \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps="$( \

--- a/25/alpine/Dockerfile
+++ b/25/alpine/Dockerfile
@@ -39,8 +39,8 @@ RUN set -xe \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
 	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
-	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
-	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& { find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true; } \
+	&& { find /usr/local -name src | xargs -r find | xargs rmdir -vp || true; } \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps="$( \

--- a/26/alpine/Dockerfile
+++ b/26/alpine/Dockerfile
@@ -39,8 +39,8 @@ RUN set -xe \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
 	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
-	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
-	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& { find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true; } \
+	&& { find /usr/local -name src | xargs -r find | xargs rmdir -vp || true; } \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps="$( \

--- a/27/alpine/Dockerfile
+++ b/27/alpine/Dockerfile
@@ -39,8 +39,8 @@ RUN set -xe \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
 	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
-	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
-	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& { find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true; } \
+	&& { find /usr/local -name src | xargs -r find | xargs rmdir -vp || true; } \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps="$( \

--- a/28/alpine/Dockerfile
+++ b/28/alpine/Dockerfile
@@ -39,8 +39,8 @@ RUN set -xe \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
 	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
-	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
-	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& { find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true; } \
+	&& { find /usr/local -name src | xargs -r find | xargs rmdir -vp || true; } \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps="$( \

--- a/29/alpine/Dockerfile
+++ b/29/alpine/Dockerfile
@@ -39,8 +39,8 @@ RUN set -xe \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
 	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
-	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
-	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& { find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true; } \
+	&& { find /usr/local -name src | xargs -r find | xargs rmdir -vp || true; } \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps="$( \

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -39,8 +39,8 @@ RUN set -xe \
 	  && make install ) \
 	&& rm -rf $ERL_TOP \
 	&& find /usr/local -regex '/usr/local/lib/erlang/\(lib/\|erts-\).*/\(man\|doc\|obj\|c_src\|emacs\|info\|examples\)' | xargs rm -rf \
-	&& find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true \
-	&& find /usr/local -name src | xargs -r find | xargs rmdir -vp || true \
+	&& { find /usr/local -name src | xargs -r find | grep -v '\.hrl$' | xargs rm -v || true; } \
+	&& { find /usr/local -name src | xargs -r find | xargs rmdir -vp || true; } \
 	&& scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local | xargs -r strip --strip-all \
 	&& scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local | xargs -r strip --strip-unneeded \
 	&& runDeps="$( \


### PR DESCRIPTION
While digging into why https://github.com/docker-library/official-images/pull/21757 Alpine builds don't seem to be published for amd64, I found that the `|| true` in the middle of these long `&&` chains is interacting poorly.

I'd really suggest dropping the `&&` chains entirely and using `set -eux;` and semicolons instead, but this is the lowest-impact change that fixes the bug so that the chain stops at the correct failure instead of continuing.

This exhibits something like this, in the `set -x` output:

```console
make[3]: Entering directory '/usr/src/otp_src_29.0.3/lib/wx/src'
 ERLC	../ebin/gl.beam
sys/unix/sys_signal_stack.c:103:sys_sigaltstack(): Internal error: Failed to set alternate signal stack
make[3]: *** [Makefile:115: ../ebin/gl.beam] Aborted (core dumped)
make[3]: Leaving directory '/usr/src/otp_src_29.0.3/lib/wx/src'
make[2]: *** [/usr/src/otp_src_29.0.3/make/otp_subdir.mk:31: opt] Error 2
make[2]: Leaving directory '/usr/src/otp_src_29.0.3/lib/wx'
make[1]: *** [/usr/src/otp_src_29.0.3/make/otp_subdir.mk:31: opt] Error 2
make[1]: Leaving directory '/usr/src/otp_src_29.0.3/lib'
make: *** [Makefile:693: tertiary_bootstrap] Error 2
+ true
+ find /usr/local -name src
+ xargs -r find
```